### PR TITLE
Give mjcontainer some height

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,25 @@ Start the dev server
 ```sh
 $ npm start
 ```
+Alternatively, you can clone the grapesjs repository in a different directory, `npm link` it and use that as the grapesjs dependency. This lets you simultaneously run grapesjs-mjml and grapesjs from source.
 
+Install grapesjs and run the webpack watcher in it:
+```sh
+$ git clone https://github.com/artf/grapesjs
+$ cd grapesjs
+$ npm install
+$ npm link
+$ webpack --watch
+```
 
+Install grapesjs-mjml, link the grapesjs repo from above and start the dev server:
+
+```sh
+$ git clone https://github.com/artf/grapesjs-mjml
+$ npm install
+$ npm link grapesjs
+$ npm run
+```
 
 ## License
 

--- a/src/components.js
+++ b/src/components.js
@@ -292,6 +292,7 @@ export default (editor, opt = {}) => {
         ],
         style: {
           width: '600px',
+          height: '100%'
         },
       }),
     }),{


### PR DESCRIPTION
We're starting from blank documents and the current state won't allow you to add blocks to the <mj-container> as (i think) the Sorter can find a location in a div with height 0. As you can view the <mj-container> as the "body" tag I've given it `height:100%`.

Also updated the README with a method for running grapesjs-mjml with a source version of grapesjs.