### PR TITLE
Updated README examples to work with grapesjs v0.15.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,25 @@ Supported components:
 <script src="path/to/grapesjs-mjml.min.js"></script>
 
 <div id="gjs">
-  <!-- Your MJML body here -->
-  <mj-container>
-        <mj-section>
-          <mj-column>
-            <mj-text>My Company</mj-text>
-          </mj-column>
-        </mj-section>
-  <mj-container>
+  <mjml>
+    <mj-body>
+      <!-- Your MJML body here -->
+      <mj-container>
+            <mj-section>
+              <mj-column>
+                <mj-text>My Company</mj-text>
+              </mj-column>
+            </mj-section>
+      <mj-container>
+    </mj-body>
+  </mjml>
 </div>
 
 <script type="text/javascript">
   var editor = grapesjs.init({
       fromElement: 1,
       container : '#gjs',
+      avoidInlineStyle : false,
       plugins: ['grapesjs-mjml'],
       pluginsOpts: {
         'grapesjs-mjml': {/* ...options */}
@@ -85,6 +90,7 @@ import grapesJSMJML from 'grapesjs-mjml'
 grapesJS.init({
    fromElement: 1,
    container : '#gjs',
+   avoidInlineStyle : false,
    plugins: [grapesJSMJML],
    pluginsOpts: {
       [grapesJSMJML]: {/* ...options */}


### PR DESCRIPTION
With the grapesjs v0.15.8 release that now defaults the `config.avoidInlineStyle` to being true, it resulted in a number of the Style Manager setting elements breaking. As the Style Manager is reliant on this setting being false for styling to work, I've updated the README to illustrate that 😄 

An example of where this caused an issue was #135 

If there's any issues with this please let me know.