### PR TITLE
chore(init): remove duplicate devicePreviewMode config set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,9 +66,6 @@ export default (editor, opt = {}) => {
     ...opt,
   };
 
-  // Change some config
-  config.devicePreviewMode = 1;
-
   // I need to prevent forced class creation as classes aren't working
   // at the moment
   config.forceClass = 0;


### PR DESCRIPTION
We are setting it twice to the same value. The next set is a few lines after this deleted line.