### PR TITLE
Merge pull request #162 from mazuschlag/master

### DIFF
--- a/src/command-export-mjml.js
+++ b/src/command-export-mjml.js
@@ -5,7 +5,8 @@ export default (editor, opt = {}) => {
   const codeViewer = editor.CodeManager.getViewer('CodeMirror').clone();
   const container = document.createElement('div');
   const cmdm = editor.Commands;
-  container.style = 'display: flex; justify-content: space-between;';
+  container.style.display = 'flex';
+  container.style.justifyContent = 'space-between';
 
   // Init code viewer
   codeViewer.set({
@@ -35,7 +36,10 @@ export default (editor, opt = {}) => {
       const cm = ecm.getViewer('CodeMirror').clone();
       const txtarea = document.createElement('textarea');
       const el = document.createElement('div');
-      el.style = 'flex:1 0 auto; padding:5px; max-width:50%; box-sizing:border-box;';
+      el.style.flex = '1 0 auto';
+      el.style.padding = '5px';
+      el.style.maxWidth = '50%';
+      el.style.boxSizing = 'border-box';
 
       const codeEditor = cm.set({
         label: label,

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -47,7 +47,7 @@ export default (editor, { dc, coreMjmlModel, coreMjmlView }) => {
       },
 
       renderStyle() {
-        this.el.style = this.el.getAttribute('style') + this.attributes.style;
+        this.el.setAttribute('style', `${this.el.getAttribute('style') + this.attributes.style}`);
       },
 
       renderContent() {

--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -79,7 +79,7 @@ export default (editor, { dc, opt, coreMjmlModel, coreMjmlView, sandboxEl }) => 
       },
 
       renderStyle() {
-        this.el.style = this.el.getAttribute('style') + this.attributes.style;
+        this.el.setAttribute('style', `${this.el.getAttribute('style') + this.attributes.style}`);
       },
 
       getMjmlTemplate() {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -231,7 +231,7 @@ export default (editor, opt = {}) => {
 
 
     renderStyle() {
-      this.el.style.cssText = this.attributes.style.cssText;
+      this.el.style.cssText = this.attributes.style;
     },
 
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -231,7 +231,7 @@ export default (editor, opt = {}) => {
 
 
     renderStyle() {
-      this.el.style = this.attributes.style;
+      this.el.style.cssText = this.attributes.style.cssText;
     },
 
 


### PR DESCRIPTION
IE11 does not like setting an element's style via the style attribute directly (ex: el.style = 'display: block;'). Technically el.style is a read only attribute, but most other browsers ignore this rule. IE11 is more strict, so it was breaking everything.