### PR TITLE
Merged style-default into style on init (#163) Closes #127

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -44,7 +44,7 @@ export default (editor, opt = {}) => {
   let coreMjmlModel = {
     init() {
       const attrs = { ...this.get('attributes') };
-      const style = { ...this.get('style') };
+      const style = { ...this.get('style-default'), ...this.get('style') };
 
       for (let prop in style) {
         if (!(prop in attrs)) {


### PR DESCRIPTION
All styles should show correct value in style manager panel.

### Example

mj-image style-default
```
'style-default': {
  'padding-top': '10px',
  'padding-bottom': '10px',
  'padding-right': '25px',
  'padding-left': '25px',
  'align': 'center',
},
```

before:
![截圖 2020-01-10 上午11 07 50](https://user-images.githubusercontent.com/5094008/72122642-8c97e880-3399-11ea-96f0-8dab014ce0c2.png)

after:
![截圖 2020-01-10 上午11 08 59](https://user-images.githubusercontent.com/5094008/72122672-a0434f00-3399-11ea-9e9b-7bd643b0f3f7.png)

Related #127 