### PR TITLE
fix: don't apply extra mj-body when the parent is not mj-body

### DIFF
--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -39,7 +39,8 @@ export default (editor, { dc, coreMjmlModel, coreMjmlView }) => {
 
       getMjmlTemplate() {
         let parentView = this.model.parent().view;
-        if (parentView.getInnerMjmlTemplate) {
+        let parentTag = this.model.parent().attributes.tagName;
+        if (parentView.getInnerMjmlTemplate && parentTag === 'mj-body') {
           let mjmlBody = coreMjmlView.getInnerMjmlTemplate.call(parentView);
           return {
             start: `<mjml><mj-body>${mjmlBody.start}`,


### PR DESCRIPTION
This prevents mj-body logic getting added when the parent of the mj-section is actually a mj-wrapper

fixes https://github.com/artf/grapesjs-mjml/issues/150

```html
<mj-body>
  <mj-wrapper border="1px solid #000000" padding="50px 30px">
    <mj-section border-top="1px solid #aaaaaa" border-left="1px solid #aaaaaa" border-right="1px solid #aaaaaa" padding="20px">
      <mj-column>
        <mj-image padding="0" src="https://via.placeholder.com/150" />
      </mj-column>
    </mj-section>
    <mj-section border-left="1px solid #aaaaaa" border-right="1px solid #aaaaaa" padding="20px" border-bottom="1px solid #aaaaaa">
      <mj-column border="1px solid #dddddd">
        <mj-text padding="20px"> First line of text </mj-text>
        <mj-divider border-width="1px" border-style="dashed" border-color="lightgrey" padding="0 20px" />
        <mj-text padding="20px"> Second line of text </mj-text>
      </mj-column>
    </mj-section>
  </mj-wrapper>
</mj-body>
```
before:
![before](https://user-images.githubusercontent.com/7842510/85998984-caea9800-ba0b-11ea-9ea8-bfd9ebf94bee.png)

after:
![after](https://user-images.githubusercontent.com/7842510/85998987-cb832e80-ba0b-11ea-8725-b804337187a4.png)

