### PR TITLE
fix: mj-group not selecting child correctly

### DIFF
--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -29,6 +29,10 @@ export default (editor, { dc, coreMjmlModel, coreMjmlView }) => {
           end: `</mj-body></mjml>`,
         };
       },
+
+      getChildrenSelector() {
+        return 'div';
+      },
     }
   });
 };


### PR DESCRIPTION
This caused the creation of an additional div and rendered style attributes like background-color incorrectly

```html
<mj-body>
  <!-- Intro text -->
  <mj-section background-color="#eaeffa">
    <mj-group background-color="#fffadd">
      <mj-column>
        <mj-text font-style="italic" font-size="20px" font-family="Helvetica Neue" color="#626262">My Awesome
          Text
        </mj-text>
        <mj-text color="#525252">
          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin rutrum enim eget magna efficitur, eu
          semper augue semper.
          Aliquam erat volutpat. Cras id dui lectus. Vestibulum sed finibus lectus, sit amet suscipit nibh. Proin
          nec
          commodo purus. Sed eget nulla elit. Nulla aliquet mollis faucibus.
        </mj-text>
        <mj-button background-color="#F45E43" href="#">Learn more</mj-button>
      </mj-column>
    </mj-group>
  </mj-section>
</mj-body>
```
before:
![before](https://user-images.githubusercontent.com/7842510/85998637-5c0d3f00-ba0b-11ea-972f-3fbae1d7e4bb.png)

after:
![after](https://user-images.githubusercontent.com/7842510/85998639-5ca5d580-ba0b-11ea-9a4d-da3e5e8ac01a.png)