### PR TITLE
Fix child render in wrapper component after drop a component

### DIFF
--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -33,7 +33,13 @@ export default (editor, { dc, coreMjmlModel, coreMjmlView }) => {
       getChildrenSelector() {
         return 'table tr td';
       },
-
+      init() {
+        coreMjmlView.init.call(this);
+        this.listenTo(this.model.get('components'), 'add remove', function() {
+          this.getChildrenContainer().innerHTML = this.model.get('content');
+          this.renderChildren();
+        });
+      },
     }
   });
 };


### PR DESCRIPTION
When you drop a component in `mj-wrapper`, the order is not respected:
**before**
![before](https://user-images.githubusercontent.com/2937198/94318744-7c588580-ff89-11ea-9286-163756f44600.gif)
**after**
![after](https://user-images.githubusercontent.com/2937198/94318762-84b0c080-ff89-11ea-96ec-a327e8e15004.gif)
