### PR TITLE
Fix icon-size styling for Social / SocialElement

### DIFF
--- a/src/components/SocialElement.js
+++ b/src/components/SocialElement.js
@@ -21,7 +21,6 @@ export default (editor, { dc, coreMjmlModel, coreMjmlView }) => {
         ],
         'style-default': {
           'align': 'center',
-          'icon-size': '20px',
           'font-size': '13px',
           'line-height': '22px',
         },


### PR DESCRIPTION
Having style-default with icon-size for both the Social component as well as the SocialElement component, the icon-size styling stops working if modified from the parent.
The style on the SocialElement overrides that of the Social component (wrapper) in these cases.

Since icon-size is not defined as stylable in SocialElement, we can simply remove it here and rely on the parent's styling.