### PR TITLE
[Fixes #295] Updating Section.draggable attribute to true to Enable Dropping Sections onto a Blank Canvas.

### DIFF
--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -11,7 +11,7 @@ export default (editor, { dc, coreMjmlModel, coreMjmlView }) => {
       ...coreMjmlModel,
       defaults: {
         name: editor.I18n.t('grapesjs-mjml.components.names.section'),
-        draggable: '[data-gjs-type=mj-body], [data-gjs-type=mj-wrapper]',
+        draggable: true,
         droppable: '[data-gjs-type=mj-column]',
         'style-default': {
           'padding-left': '0px',


### PR DESCRIPTION
### What This PR Fixes:
There is currently a bug detailed in this [issue](https://github.com/artf/grapesjs-mjml/issues/295) where, when you are using `grapesjs` with the `grapesjs-mjml` plugin, and attempt to add a Section component to a blank Canvas, you are not able to, and receive this warning (logged to the browser console):

```json
{
    "errors": [
        "Target collection not found",
        "Component not draggable, acceptable by [[data-gjs-type=mj-body], [data-gjs-type=mj-wrapper]]"
    ],
    "model": {
        "tagName": "mj-section",
        "type": "mj-section"
    },
    "context": "sorter",
    "level": "warning"
}
```
#### Video:

Shows me removing all Section components on a canvas, and then attempting to add a new Section component to the blank Canvas - Fails w/ Warning Logged to Console:

[screen-capture (25).webm](https://user-images.githubusercontent.com/62859552/191595013-37e98684-6daa-4266-bdaf-cb6f16f24435.webm)

### What Caused This Bug:
The `src/components/Section.js` component currently has a `draggable` attribute set to:

```js
draggable: '[data-gjs-type=mj-body], [data-gjs-type=mj-wrapper]',
```

However, when there are no components on the canvas (by deleting them all or starting with a blank canvas), you cannot drag and place a Section component onto the canvas because the accepted draggable parent components do not exist.

### How to Fix This Bug:
If we set `draggable` to `true`, we are now able to successfully able to drag and drop Section components onto a blank canvas:

```js
draggable: true,
```

#### Video:
Shows me adding a Section component to a Blank Canvas - Now works:
[screen-capture (24).webm](https://user-images.githubusercontent.com/62859552/191594260-9ae01c2c-474b-484c-8716-1cfc5db90014.webm)
